### PR TITLE
[Feat] relocate complete function and new feature to reset and restart tour

### DIFF
--- a/lib/src/components/features_child.dart
+++ b/lib/src/components/features_child.dart
@@ -295,47 +295,49 @@ class _FeaturesChildState extends State<FeaturesChild>
   Widget build(BuildContext context) {
     return rect == null
         ? const Center(child: CircularProgressIndicator())
-        : Stack(
-          children: [
-            // Border widget
-            Positioned.fromRect(
-              rect: rect!.inflate(widget.childConfig.borderSizeInflate),
-              child: AnimatedBuilder(
-                animation: _scaleAnimation,
-                builder: (context, child) {
-                  return Transform.scale(
-                    scale: _scaleAnimation.value,
-                    child: Material(
-                      color: widget.childConfig.backgroundColor,
-                      shape: widget.childConfig.shapeBorder,
-                    ),
-                  );
-                },
-              ),
-            ),
-
-            // Child widget.
-            if (widget.childConfig.enableAnimation &&
-                widget.childConfig.isAnimateChild)
+        : Scaffold(
+          resizeToAvoidBottomInset: true,
+          backgroundColor: Colors.transparent,
+          body: Stack(
+            children: [
+              // Border widget
               Positioned.fromRect(
-                rect: rect!,
+                rect: rect!.inflate(widget.childConfig.borderSizeInflate),
                 child: AnimatedBuilder(
                   animation: _scaleAnimation,
                   builder: (context, child) {
                     return Transform.scale(
                       scale: _scaleAnimation.value,
-                      child: widget.child,
+                      child: Material(
+                        color: widget.childConfig.backgroundColor,
+                        shape: widget.childConfig.shapeBorder,
+                      ),
                     );
                   },
                 ),
-              )
-            else
-              Positioned.fromRect(rect: rect!, child: widget.child),
+              ),
 
-            // Introduction widget.
-            Positioned.fromRect(
-              rect: introduceRect,
-              child: IgnorePointer(
+              // Child widget.
+              if (widget.childConfig.enableAnimation &&
+                  widget.childConfig.isAnimateChild)
+                Positioned.fromRect(
+                  rect: rect!,
+                  child: AnimatedBuilder(
+                    animation: _scaleAnimation,
+                    builder: (context, child) {
+                      return Transform.scale(
+                        scale: _scaleAnimation.value,
+                        child: widget.child,
+                      );
+                    },
+                  ),
+                )
+              else
+                Positioned.fromRect(rect: rect!, child: widget.child),
+
+              // Introduction widget.
+              Positioned.fromRect(
+                rect: introduceRect,
                 child: Padding(
                   padding: widget.padding,
                   child: Align(
@@ -348,45 +350,36 @@ class _FeaturesChildState extends State<FeaturesChild>
                   ),
                 ),
               ),
-            ),
+              // Skip text widget.
+              if (!(widget.isLastState && widget.doneConfig.enabled) &&
+                  widget.skipConfig.enabled)
+                Positioned.fill(
+                  child: Align(
+                    alignment: widget.skipConfig.alignment,
+                    child: widget.skip,
+                  ),
+                ),
 
-            Scaffold(
-              resizeToAvoidBottomInset: true,
-              backgroundColor: Colors.transparent,
-              body: Stack(
-                children: [
-                  // Skip text widget.
-                  if (!(widget.isLastState && widget.doneConfig.enabled) &&
-                      widget.skipConfig.enabled)
-                    Positioned.fill(
-                      child: Align(
-                        alignment: widget.skipConfig.alignment,
-                        child: widget.skip,
-                      ),
-                    ),
+              // Next text widget.
+              if (!(widget.isLastState && widget.doneConfig.enabled) &&
+                  widget.nextConfig.enabled)
+                Positioned.fill(
+                  child: Align(
+                    alignment: widget.nextConfig.alignment,
+                    child: widget.next,
+                  ),
+                ),
 
-                  // Next text widget.
-                  if (!(widget.isLastState && widget.doneConfig.enabled) &&
-                      widget.nextConfig.enabled)
-                    Positioned.fill(
-                      child: Align(
-                        alignment: widget.nextConfig.alignment,
-                        child: widget.next,
-                      ),
-                    ),
-
-                  // Done text widget.
-                  if (widget.isLastState && widget.doneConfig.enabled)
-                    Positioned.fill(
-                      child: Align(
-                        alignment: widget.doneConfig.alignment,
-                        child: widget.done,
-                      ),
-                    ),
-                ],
-              ),
-            ),
-          ],
+              // Done text widget.
+              if (widget.isLastState && widget.doneConfig.enabled)
+                Positioned.fill(
+                  child: Align(
+                    alignment: widget.doneConfig.alignment,
+                    child: widget.done,
+                  ),
+                ),
+            ],
+          ),
         );
   }
 }

--- a/lib/src/features_tour_controller.dart
+++ b/lib/src/features_tour_controller.dart
@@ -492,17 +492,7 @@ class FeaturesTourController {
   ///
   /// **Use Cases:**
   ///
-  /// 1. **Custom button actions in introduction widgets:**
-  ///    ```dart
-  ///    SdfButton(
-  ///      buttonLabel: 'Continue',
-  ///      onAction: () {
-  ///        controller.complete(IntroduceResult.next);
-  ///      },
-  ///    )
-  ///    ```
-  ///
-  /// 2. **Programmatic tour navigation:**
+  /// 1. **Programmatic tour navigation:**
   ///    ```dart
   ///    // Skip tour based on user preference
   ///    if (userWantsToSkip) {
@@ -510,7 +500,7 @@ class FeaturesTourController {
   ///    }
   ///    ```
   ///
-  /// 3. **External events triggering tour progression:**
+  /// 2. **External events triggering tour progression:**
   ///    ```dart
   ///    // Timer auto-advances tour
   ///    Timer(Duration(seconds: 5), () {
@@ -518,7 +508,7 @@ class FeaturesTourController {
   ///    });
   ///    ```
   ///
-  /// 4. **Custom skip/next logic based on user actions:**
+  /// 3. **Custom skip/next logic based on user actions:**
   ///    ```dart
   ///    // Complete based on user interaction
   ///    onUserCompletedTask() {

--- a/lib/src/features_tour_controller.dart
+++ b/lib/src/features_tour_controller.dart
@@ -471,59 +471,24 @@ class FeaturesTourController {
     }
   }
 
-  /// Completes the current tour introduction with the specified result.
-  ///
-  /// This method programmatically finishes the currently displayed tour step
-  /// by completing its internal completer with the given [result].
-  ///
-  /// **Parameters:**
-  ///
-  /// [result] - The result to complete with:
-  /// - [IntroduceResult.next] - Move to the next tour item in sequence
-  /// - [IntroduceResult.skip] - Skip the entire remaining tour
-  /// - [IntroduceResult.done] - Mark the tour as complete
-  /// - [IntroduceResult.disabled] - Mark current step as disabled
-  /// - [IntroduceResult.notMounted] - Mark current step as not mounted
-  ///
-  /// **Behavior:**
-  /// - Safe to call multiple times - only completes once if active
-  /// - Does nothing if no tour step is currently showing
-  /// - Triggers the tour loop to process the result and decide next action
-  ///
-  /// **Use Cases:**
-  ///
-  /// 1. **Programmatic tour navigation:**
-  ///    ```dart
-  ///    // Skip tour based on user preference
-  ///    if (userWantsToSkip) {
-  ///      controller.complete(IntroduceResult.skip);
-  ///    }
-  ///    ```
-  ///
-  /// 2. **External events triggering tour progression:**
-  ///    ```dart
-  ///    // Timer auto-advances tour
-  ///    Timer(Duration(seconds: 5), () {
-  ///      controller.complete(IntroduceResult.next);
-  ///    });
-  ///    ```
-  ///
-  /// 3. **Custom skip/next logic based on user actions:**
-  ///    ```dart
-  ///    // Complete based on user interaction
-  ///    onUserCompletedTask() {
-  ///      controller.complete(IntroduceResult.done);
-  ///    }
-  ///    ```
-  ///
-  /// **Important Notes:**
-  /// - Calling with [IntroduceResult.skip] will end the entire tour
-  /// - Calling with [IntroduceResult.next] continues to the next item
-  /// - Calling with [IntroduceResult.done] marks the tour as complete
-  /// - This method is used internally by the built-in Next/Skip/Done buttons
-  void complete(IntroduceResult result) {
+  /// continues to the next item
+  void next() {
     if (_introduceCompleter != null && !_introduceCompleter!.isCompleted) {
-      _introduceCompleter?.complete(result);
+      _introduceCompleter?.complete(IntroduceResult.next);
+    }
+  }
+
+  /// end the entire tour
+  void skip() {
+    if (_introduceCompleter != null && !_introduceCompleter!.isCompleted) {
+      _introduceCompleter?.complete(IntroduceResult.skip);
+    }
+  }
+
+  ///  marks the tour as complete
+  void done() {
+    if (_introduceCompleter != null && !_introduceCompleter!.isCompleted) {
+      _introduceCompleter?.complete(IntroduceResult.done);
     }
   }
 
@@ -549,6 +514,12 @@ class FeaturesTourController {
     final doneConfig = state.widget.doneConfig ?? DoneConfig.global;
 
     _introduceCompleter = Completer<IntroduceResult>();
+
+    void complete(IntroduceResult result) {
+      if (_introduceCompleter != null && !_introduceCompleter!.isCompleted) {
+        _introduceCompleter?.complete(result);
+      }
+    }
 
     void skipAction() => complete(IntroduceResult.skip);
 
@@ -901,7 +872,7 @@ class FeaturesTourController {
     // Cancel current tour if running (don't wait - start() will handle it)
     if (_isIntroducing) {
       _logger?.debug(() => 'Cancelling current tour...');
-      complete(IntroduceResult.skip);
+      skip();
     }
 
     // Clear shown flags FIRST so they're ready when start() is called

--- a/lib/src/features_tour_controller.dart
+++ b/lib/src/features_tour_controller.dart
@@ -471,6 +471,72 @@ class FeaturesTourController {
     }
   }
 
+  /// Completes the current tour introduction with the specified result.
+  ///
+  /// This method programmatically finishes the currently displayed tour step
+  /// by completing its internal completer with the given [result].
+  ///
+  /// **Parameters:**
+  ///
+  /// [result] - The result to complete with:
+  /// - [IntroduceResult.next] - Move to the next tour item in sequence
+  /// - [IntroduceResult.skip] - Skip the entire remaining tour
+  /// - [IntroduceResult.done] - Mark the tour as complete
+  /// - [IntroduceResult.disabled] - Mark current step as disabled
+  /// - [IntroduceResult.notMounted] - Mark current step as not mounted
+  ///
+  /// **Behavior:**
+  /// - Safe to call multiple times - only completes once if active
+  /// - Does nothing if no tour step is currently showing
+  /// - Triggers the tour loop to process the result and decide next action
+  ///
+  /// **Use Cases:**
+  ///
+  /// 1. **Custom button actions in introduction widgets:**
+  ///    ```dart
+  ///    SdfButton(
+  ///      buttonLabel: 'Continue',
+  ///      onAction: () {
+  ///        controller.complete(IntroduceResult.next);
+  ///      },
+  ///    )
+  ///    ```
+  ///
+  /// 2. **Programmatic tour navigation:**
+  ///    ```dart
+  ///    // Skip tour based on user preference
+  ///    if (userWantsToSkip) {
+  ///      controller.complete(IntroduceResult.skip);
+  ///    }
+  ///    ```
+  ///
+  /// 3. **External events triggering tour progression:**
+  ///    ```dart
+  ///    // Timer auto-advances tour
+  ///    Timer(Duration(seconds: 5), () {
+  ///      controller.complete(IntroduceResult.next);
+  ///    });
+  ///    ```
+  ///
+  /// 4. **Custom skip/next logic based on user actions:**
+  ///    ```dart
+  ///    // Complete based on user interaction
+  ///    onUserCompletedTask() {
+  ///      controller.complete(IntroduceResult.done);
+  ///    }
+  ///    ```
+  ///
+  /// **Important Notes:**
+  /// - Calling with [IntroduceResult.skip] will end the entire tour
+  /// - Calling with [IntroduceResult.next] continues to the next item
+  /// - Calling with [IntroduceResult.done] marks the tour as complete
+  /// - This method is used internally by the built-in Next/Skip/Done buttons
+  void complete(IntroduceResult result) {
+    if (_introduceCompleter != null && !_introduceCompleter!.isCompleted) {
+      _introduceCompleter?.complete(result);
+    }
+  }
+
   Future<IntroduceResult> _showIntroduce(
     BuildContext context,
     _FeaturesTourState state,
@@ -493,12 +559,6 @@ class FeaturesTourController {
     final doneConfig = state.widget.doneConfig ?? DoneConfig.global;
 
     _introduceCompleter = Completer<IntroduceResult>();
-
-    void complete(IntroduceResult result) {
-      if (_introduceCompleter != null && !_introduceCompleter!.isCompleted) {
-        _introduceCompleter?.complete(result);
-      }
-    }
 
     void skipAction() => complete(IntroduceResult.skip);
 
@@ -791,5 +851,100 @@ class FeaturesTourController {
   /// Gets the key for shared preferences.
   String _getPrefKey(_FeaturesTourState state) {
     return '${FeaturesTour._prefix}_${pageName}_${state.widget.index}';
+  }
+
+  /// Resets the tour state from a specific index by clearing shown flags
+  /// and preparing states for restart.
+  ///
+  /// This method does NOT automatically start the tour. After calling [reset],
+  /// you must manually call [start] to begin the tour from the target index.
+  ///
+  /// **What it does:**
+  /// - Cancels the current tour if one is running
+  /// - Clears SharedPreferences "shown" flags for [targetIndex] and all indices >= targetIndex
+  /// - Restores all cached states to the active states map
+  ///
+  /// **Use Cases:**
+  /// - Implementing "go to previous" functionality where you want full control
+  ///   over when the tour restarts
+  /// - Resetting tour progress to allow re-showing previously seen items
+  /// - Preparing the tour for a custom restart sequence
+  ///
+  /// [targetIndex] - The index to reset from. This index and all higher indices
+  ///                 will have their "shown" flags cleared in SharedPreferences.
+  ///
+  /// **Important Notes:**
+  /// - After calling [reset], you MUST call [start] with `force: true` to show
+  ///   the reset items, otherwise they may be skipped
+  /// - If a tour is currently running, it will be cancelled with [IntroduceResult.skip]
+  /// - The overlay from the previous tour will be removed when you call [start]
+  ///
+  /// Example:
+  /// ```dart
+  /// // Reset to index 1.0 and manually restart
+  /// await controller.reset(1.0);
+  /// await controller.start(
+  ///   context,
+  ///   firstIndex: 1.0,
+  ///   force: true, // Required to show reset items
+  ///   delay: Duration.zero,
+  /// );
+  ///
+  /// // Reset and restart with custom state tracking
+  /// await controller.reset(2.0);
+  /// await controller.start(
+  ///   context,
+  ///   firstIndex: 2.0,
+  ///   force: true,
+  ///   onState: (state) {
+  ///     if (state is TourIntroducing) {
+  ///       print('Now showing index: ${state.index}');
+  ///     }
+  ///   },
+  /// );
+  /// ```
+  Future<void> reset(double targetIndex) async {
+    if (_debugLog) {
+      _logger?.info(() => 'Restarting tour from index $targetIndex');
+    }
+
+    // Cancel current tour if running (don't wait - start() will handle it)
+    if (_isIntroducing) {
+      _logger?.debug(() => 'Cancelling current tour...');
+      complete(IntroduceResult.skip);
+    }
+
+    // Clear shown flags FIRST so they're ready when start() is called
+    await _clearShownFlagsFrom(targetIndex);
+
+    // Restore states that need to be shown again
+    _states
+      ..clear()
+      ..addAll(_cachedStates);
+  }
+
+  /// Clears the "shown" flags in SharedPreferences for all items
+  /// from [startIndex] onwards (inclusive)
+  Future<void> _clearShownFlagsFrom(double startIndex) async {
+    _prefs ??= await SharedPreferences.getInstance();
+
+    final indexesToClear = _cachedStates.keys.where((idx) => idx >= startIndex);
+
+    for (final index in indexesToClear) {
+      final state = _cachedStates[index];
+      if (state != null) {
+        final key = _getPrefKey(state);
+        await _prefs!.remove(key);
+        _introducedIndexes.remove(index);
+
+        if (_debugLog) {
+          _logger?.debug(() => 'Cleared shown flag for index $index');
+        }
+      }
+    }
+
+    if (_debugLog) {
+      _logger?.info(() => 'Cleared ${indexesToClear.length} shown flags');
+    }
   }
 }

--- a/test/extra_test.dart
+++ b/test/extra_test.dart
@@ -630,5 +630,987 @@ void main() {
         ]),
       );
     });
+
+    testWidgets('complete() with IntroduceResult.next moves to next step', (
+      tester,
+    ) async {
+      final controller = FeaturesTourController('App');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: App(
+            tours: [
+              FeaturesTour(
+                index: 1,
+                controller: controller,
+                introduce: const Text('a.intro'),
+                child: const Text('a'),
+              ),
+              FeaturesTour(
+                index: 2,
+                controller: controller,
+                introduce: const Text('b.intro'),
+                child: const Text('b'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      final context = tester.element(find.byType(App));
+
+      await tester.runAsync(() async {
+        await controller.start(
+          context,
+          force: true,
+          delay: Duration.zero,
+          onState: (state) async {
+            collectedStates.add(state);
+            if (state case TourIntroducing(index: final index)) {
+              await tester.pump();
+              if (index == 1) {
+                expect(find.text('a.intro'), findsOneWidget);
+                // Programmatically complete with next
+                controller.complete(IntroduceResult.next);
+              } else if (index == 2) {
+                expect(find.text('b.intro'), findsOneWidget);
+                controller.complete(IntroduceResult.done);
+              }
+            }
+          },
+        );
+      });
+
+      await tester.pumpAndSettle();
+
+      expect(
+        collectedStates,
+        containsAllInOrder([
+          isA<TourPreDialogHidden>(),
+          isA<TourIntroducing>().having((s) => s.index, 'index', 1),
+          isA<TourIntroduceResultEmitted>().having(
+            (s) => s.result,
+            'result',
+            IntroduceResult.next,
+          ),
+          isA<TourIntroducing>().having((s) => s.index, 'index', 2),
+          isA<TourIntroduceResultEmitted>().having(
+            (s) => s.result,
+            'result',
+            IntroduceResult.done,
+          ),
+          isA<TourCompleted>(),
+        ]),
+      );
+    });
+
+    testWidgets('complete() with IntroduceResult.skip stops the tour', (
+      tester,
+    ) async {
+      final controller = FeaturesTourController('App');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: App(
+            tours: [
+              FeaturesTour(
+                index: 1,
+                controller: controller,
+                introduce: const Text('a.intro'),
+                child: const Text('a'),
+              ),
+              FeaturesTour(
+                index: 2,
+                controller: controller,
+                introduce: const Text('b.intro'),
+                child: const Text('b'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      final context = tester.element(find.byType(App));
+
+      await tester.runAsync(() async {
+        await controller.start(
+          context,
+          force: true,
+          delay: Duration.zero,
+          onState: (state) async {
+            collectedStates.add(state);
+            if (state case TourIntroducing(index: final index)) {
+              await tester.pump();
+              if (index == 1) {
+                expect(find.text('a.intro'), findsOneWidget);
+                // Programmatically skip the entire tour
+                controller.complete(IntroduceResult.skip);
+              } else if (index == 2) {
+                fail('Should not reach index 2 after skip');
+              }
+            }
+          },
+        );
+      });
+
+      await tester.pumpAndSettle();
+
+      expect(
+        collectedStates,
+        containsAllInOrder([
+          isA<TourPreDialogHidden>(),
+          isA<TourIntroducing>().having((s) => s.index, 'index', 1),
+          isA<TourIntroduceResultEmitted>().having(
+            (s) => s.result,
+            'result',
+            IntroduceResult.skip,
+          ),
+          isA<TourCompleted>(),
+        ]),
+      );
+    });
+
+    testWidgets('complete() with IntroduceResult.done completes the tour', (
+      tester,
+    ) async {
+      final controller = FeaturesTourController('App');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: App(
+            tours: [
+              FeaturesTour(
+                index: 1,
+                controller: controller,
+                introduce: const Text('a.intro'),
+                child: const Text('a'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      final context = tester.element(find.byType(App));
+
+      await tester.runAsync(() async {
+        await controller.start(
+          context,
+          force: true,
+          delay: Duration.zero,
+          onState: (state) async {
+            collectedStates.add(state);
+            if (state is TourIntroducing) {
+              await tester.pump();
+              expect(find.text('a.intro'), findsOneWidget);
+              // Complete with done result
+              controller.complete(IntroduceResult.done);
+            }
+          },
+        );
+      });
+
+      await tester.pumpAndSettle();
+
+      expect(
+        collectedStates,
+        containsAllInOrder([
+          isA<TourPreDialogHidden>(),
+          isA<TourIntroducing>(),
+          isA<TourIntroduceResultEmitted>().having(
+            (s) => s.result,
+            'result',
+            IntroduceResult.done,
+          ),
+          isA<TourCompleted>(),
+        ]),
+      );
+    });
+
+    testWidgets('complete() does nothing when tour is not active', (
+      tester,
+    ) async {
+      final controller = FeaturesTourController('App');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: App(
+            tours: [
+              FeaturesTour(
+                index: 1,
+                controller: controller,
+                introduce: const Text('a.intro'),
+                child: const Text('a'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Call complete before starting the tour - should not crash
+      controller.complete(IntroduceResult.next);
+
+      // Verify app is still functional
+      expect(find.text('a'), findsOneWidget);
+    });
+
+    testWidgets('complete() does nothing when called multiple times', (
+      tester,
+    ) async {
+      final controller = FeaturesTourController('App');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: App(
+            tours: [
+              FeaturesTour(
+                index: 1,
+                controller: controller,
+                introduce: const Text('a.intro'),
+                child: const Text('a'),
+              ),
+              FeaturesTour(
+                index: 2,
+                controller: controller,
+                introduce: const Text('b.intro'),
+                child: const Text('b'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      final context = tester.element(find.byType(App));
+
+      await tester.runAsync(() async {
+        await controller.start(
+          context,
+          force: true,
+          delay: Duration.zero,
+          onState: (state) async {
+            collectedStates.add(state);
+            if (state case TourIntroducing(index: final index)) {
+              await tester.pump();
+              if (index == 1) {
+                expect(find.text('a.intro'), findsOneWidget);
+                // Call complete multiple times - only first should take effect
+                controller.complete(IntroduceResult.next);
+              } else if (index == 2) {
+                expect(find.text('b.intro'), findsOneWidget);
+                controller.complete(IntroduceResult.done);
+              }
+            }
+          },
+        );
+      });
+
+      await tester.pumpAndSettle();
+
+      // Should have moved to next (first complete call), not skip or done
+      expect(
+        collectedStates,
+        containsAllInOrder([
+          isA<TourPreDialogHidden>(),
+          isA<TourIntroducing>().having((s) => s.index, 'index', 1),
+          isA<TourIntroduceResultEmitted>().having(
+            (s) => s.result,
+            'result',
+            IntroduceResult.next,
+          ),
+          isA<TourIntroducing>().having((s) => s.index, 'index', 2),
+          isA<TourIntroduceResultEmitted>().having(
+            (s) => s.result,
+            'result',
+            IntroduceResult.done,
+          ),
+          isA<TourCompleted>(),
+        ]),
+      );
+    });
+
+    testWidgets('complete() can be used with external events like timers', (
+      tester,
+    ) async {
+      final controller = FeaturesTourController('App');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: App(
+            tours: [
+              FeaturesTour(
+                index: 1,
+                controller: controller,
+                introduce: const Text('a.intro'),
+                child: const Text('a'),
+              ),
+              FeaturesTour(
+                index: 2,
+                controller: controller,
+                introduce: const Text('b.intro'),
+                child: const Text('b'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      final context = tester.element(find.byType(App));
+
+      var firstIntroShown = false;
+      var secondIntroShown = false;
+
+      await tester.runAsync(() async {
+        // Start tour with state tracking
+        final tourFuture = controller.start(
+          context,
+          force: true,
+          delay: Duration.zero,
+          onState: (state) async {
+            collectedStates.add(state);
+            if (state case TourIntroducing(index: final index)) {
+              await tester.pump();
+              if (index == 1) {
+                firstIntroShown = true;
+              } else if (index == 2) {
+                secondIntroShown = true;
+              }
+            }
+          },
+        );
+
+        // Wait for first introduction to appear
+        await tester.pump();
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        expect(firstIntroShown, isTrue);
+
+        // Simulate external event (e.g., timer) completing the tour
+        controller.complete(IntroduceResult.next);
+
+        // Wait for transition to second introduction
+        await tester.pump();
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        expect(secondIntroShown, isTrue);
+
+        // Complete the tour
+        controller.complete(IntroduceResult.done);
+
+        // Wait for tour to finish
+        await tourFuture;
+      });
+
+      await tester.pumpAndSettle();
+
+      // Verify tour completed successfully
+      expect(find.text('a.intro'), findsNothing);
+      expect(find.text('b.intro'), findsNothing);
+      expect(
+        collectedStates,
+        containsAllInOrder([
+          isA<TourIntroducing>().having((s) => s.index, 'index', 1),
+          isA<TourIntroducing>().having((s) => s.index, 'index', 2),
+          isA<TourCompleted>(),
+        ]),
+      );
+    });
+
+    testWidgets('complete() works correctly with all IntroduceResult types', (
+      tester,
+    ) async {
+      // Test disabled and notMounted results
+      final controller = FeaturesTourController('App');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: App(
+            tours: [
+              FeaturesTour(
+                index: 1,
+                controller: controller,
+                introduce: const Text('a.intro'),
+                child: const Text('a'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      final context = tester.element(find.byType(App));
+
+      await tester.runAsync(() async {
+        await controller.start(
+          context,
+          force: true,
+          delay: Duration.zero,
+          onState: (state) async {
+            collectedStates.add(state);
+            if (state is TourIntroducing) {
+              await tester.pump();
+              // Complete with disabled result (though this is typically internal)
+              controller.complete(IntroduceResult.disabled);
+            }
+          },
+        );
+      });
+
+      await tester.pumpAndSettle();
+
+      expect(
+        collectedStates,
+        containsAllInOrder([
+          isA<TourPreDialogHidden>(),
+          isA<TourIntroducing>(),
+          isA<TourIntroduceResultEmitted>().having(
+            (s) => s.result,
+            'result',
+            IntroduceResult.disabled,
+          ),
+          isA<TourCompleted>(),
+        ]),
+      );
+    });
+
+    testWidgets('reset() clears shown flags from target index onwards', (
+      tester,
+    ) async {
+      final controller = FeaturesTourController('App');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: App(
+            tours: [
+              FeaturesTour(
+                index: 1,
+                controller: controller,
+                introduce: const Text('a.intro'),
+                child: const Text('a'),
+              ),
+              FeaturesTour(
+                index: 2,
+                controller: controller,
+                introduce: const Text('b.intro'),
+                child: const Text('b'),
+              ),
+              FeaturesTour(
+                index: 3,
+                controller: controller,
+                introduce: const Text('c.intro'),
+                child: const Text('c'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      final context = tester.element(find.byType(App));
+
+      // First, complete the entire tour
+      await tester.runAsync(() async {
+        await controller.start(
+          context,
+          force: true,
+          delay: Duration.zero,
+          onState: (state) async {
+            if (state is TourIntroducing) {
+              await tester.pump();
+              controller.complete(IntroduceResult.next);
+            }
+          },
+        );
+      });
+
+      await tester.pumpAndSettle();
+
+      // Verify all tours are marked as shown
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool('FeaturesTour_App_1.0'), isTrue);
+      expect(prefs.getBool('FeaturesTour_App_2.0'), isTrue);
+      expect(prefs.getBool('FeaturesTour_App_3.0'), isTrue);
+
+      // Reset from index 2.0 onwards
+      await controller.reset(2);
+
+      // Need to reload prefs to get updated values
+      await prefs.reload();
+
+      // Verify flags are cleared for index 2.0 and 3.0, but not 1.0
+      expect(prefs.getBool('FeaturesTour_App_1.0'), isTrue);
+      expect(prefs.containsKey('FeaturesTour_App_2.0'), isFalse);
+      expect(prefs.containsKey('FeaturesTour_App_3.0'), isFalse);
+    });
+
+    testWidgets('reset() allows re-showing tours from target index', (
+      tester,
+    ) async {
+      final controller = FeaturesTourController('App');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: App(
+            tours: [
+              FeaturesTour(
+                index: 1,
+                controller: controller,
+                introduce: const Text('a.intro'),
+                child: const Text('a'),
+              ),
+              FeaturesTour(
+                index: 2,
+                controller: controller,
+                introduce: const Text('b.intro'),
+                child: const Text('b'),
+              ),
+              FeaturesTour(
+                index: 3,
+                controller: controller,
+                introduce: const Text('c.intro'),
+                child: const Text('c'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      final context = tester.element(find.byType(App));
+
+      // Complete the tour first
+      await tester.runAsync(() async {
+        await controller.start(
+          context,
+          force: true,
+          delay: Duration.zero,
+          onState: (state) async {
+            if (state is TourIntroducing) {
+              await tester.pump();
+              controller.complete(IntroduceResult.next);
+            }
+          },
+        );
+      });
+
+      await tester.pumpAndSettle();
+
+      // Reset from index 2.0
+      await controller.reset(2);
+
+      collectedStates.clear();
+
+      // Restart the tour with force: true
+      await tester.runAsync(() async {
+        await controller.start(
+          context,
+          firstIndex: 2,
+          force: true,
+          delay: Duration.zero,
+          onState: (state) async {
+            collectedStates.add(state);
+            if (state is TourIntroducing) {
+              await tester.pump();
+              controller.complete(IntroduceResult.next);
+            }
+          },
+        );
+      });
+
+      await tester.pumpAndSettle();
+
+      // Should show index 2 and 3 but not 1
+      expect(
+        collectedStates,
+        containsAllInOrder([
+          isA<TourIntroducing>().having((s) => s.index, 'index', 2),
+          isA<TourIntroducing>().having((s) => s.index, 'index', 3),
+          isA<TourCompleted>(),
+        ]),
+      );
+    });
+
+    testWidgets('reset() cancels currently running tour', (tester) async {
+      final controller = FeaturesTourController('App');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: App(
+            tours: [
+              FeaturesTour(
+                index: 1,
+                controller: controller,
+                introduce: const Text('a.intro'),
+                child: const Text('a'),
+              ),
+              FeaturesTour(
+                index: 2,
+                controller: controller,
+                introduce: const Text('b.intro'),
+                child: const Text('b'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      final context = tester.element(find.byType(App));
+
+      await tester.runAsync(() async {
+        // Start the tour
+        final tourFuture = controller.start(
+          context,
+          force: true,
+          delay: Duration.zero,
+          onState: (state) async {
+            collectedStates.add(state);
+            if (state case TourIntroducing(index: 1)) {
+              await tester.pump();
+              // Reset while tour is running
+              await controller.reset(1);
+            }
+          },
+        );
+
+        await tourFuture;
+      });
+
+      await tester.pumpAndSettle();
+
+      // Tour should be cancelled with skip
+      expect(
+        collectedStates,
+        containsAllInOrder([
+          isA<TourIntroducing>().having((s) => s.index, 'index', 1),
+          isA<TourIntroduceResultEmitted>().having(
+            (s) => s.result,
+            'result',
+            IntroduceResult.skip,
+          ),
+          isA<TourCompleted>(),
+        ]),
+      );
+    });
+
+    testWidgets('reset() with index 1.0 clears all shown flags', (
+      tester,
+    ) async {
+      final controller = FeaturesTourController('App');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: App(
+            tours: [
+              FeaturesTour(
+                index: 1,
+                controller: controller,
+                introduce: const Text('a.intro'),
+                child: const Text('a'),
+              ),
+              FeaturesTour(
+                index: 2,
+                controller: controller,
+                introduce: const Text('b.intro'),
+                child: const Text('b'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      final context = tester.element(find.byType(App));
+
+      // Complete the tour
+      await tester.runAsync(() async {
+        await controller.start(
+          context,
+          force: true,
+          delay: Duration.zero,
+          onState: (state) async {
+            if (state is TourIntroducing) {
+              await tester.pump();
+              controller.complete(IntroduceResult.next);
+            }
+          },
+        );
+      });
+
+      await tester.pumpAndSettle();
+
+      // Verify all are marked as shown
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool('FeaturesTour_App_1.0'), isTrue);
+      expect(prefs.getBool('FeaturesTour_App_2.0'), isTrue);
+
+      // Reset from the beginning
+      await controller.reset(1);
+
+      // Need to reload prefs to get updated values
+      await prefs.reload();
+
+      // All flags should be cleared
+      expect(prefs.containsKey('FeaturesTour_App_1.0'), isFalse);
+      expect(prefs.containsKey('FeaturesTour_App_2.0'), isFalse);
+    });
+
+    testWidgets('reset() restores all cached states to active states', (
+      tester,
+    ) async {
+      final controller = FeaturesTourController('App');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: App(
+            tours: [
+              FeaturesTour(
+                index: 1,
+                controller: controller,
+                introduce: const Text('a.intro'),
+                child: const Text('a'),
+              ),
+              FeaturesTour(
+                index: 2,
+                controller: controller,
+                introduce: const Text('b.intro'),
+                child: const Text('b'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      final context = tester.element(find.byType(App));
+
+      // Complete the tour (this unregisters states)
+      await tester.runAsync(() async {
+        await controller.start(
+          context,
+          force: true,
+          delay: Duration.zero,
+          onState: (state) async {
+            if (state is TourIntroducing) {
+              await tester.pump();
+              controller.complete(IntroduceResult.next);
+            }
+          },
+        );
+      });
+
+      await tester.pumpAndSettle();
+
+      // Reset from index 1.0
+      await controller.reset(1);
+
+      collectedStates.clear();
+
+      // Restart - should be able to show all tours again
+      await tester.runAsync(() async {
+        await controller.start(
+          context,
+          force: true,
+          delay: Duration.zero,
+          onState: (state) async {
+            collectedStates.add(state);
+            if (state is TourIntroducing) {
+              await tester.pump();
+              controller.complete(IntroduceResult.next);
+            }
+          },
+        );
+      });
+
+      await tester.pumpAndSettle();
+
+      // Both tours should be shown
+      expect(
+        collectedStates,
+        containsAllInOrder([
+          isA<TourIntroducing>().having((s) => s.index, 'index', 1),
+          isA<TourIntroducing>().having((s) => s.index, 'index', 2),
+          isA<TourCompleted>(),
+        ]),
+      );
+    });
+
+    testWidgets('reset() works correctly for implementing go-to-previous', (
+      tester,
+    ) async {
+      final controller = FeaturesTourController('App');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: App(
+            tours: [
+              FeaturesTour(
+                index: 1,
+                controller: controller,
+                introduce: const Text('a.intro'),
+                child: const Text('a'),
+              ),
+              FeaturesTour(
+                index: 2,
+                controller: controller,
+                introduce: const Text('b.intro'),
+                child: const Text('b'),
+              ),
+              FeaturesTour(
+                index: 3,
+                controller: controller,
+                introduce: const Text('c.intro'),
+                child: const Text('c'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      final context = tester.element(find.byType(App));
+
+      // Show first two tours
+      await tester.runAsync(() async {
+        await controller.start(
+          context,
+          force: true,
+          delay: Duration.zero,
+          onState: (state) async {
+            collectedStates.add(state);
+            if (state case TourIntroducing(index: final index)) {
+              await tester.pump();
+              if (index == 1 || index == 2) {
+                controller.complete(IntroduceResult.next);
+              } else if (index == 3) {
+                // User wants to go back to index 2
+                controller.complete(IntroduceResult.skip);
+              }
+            }
+          },
+        );
+      });
+
+      await tester.pumpAndSettle();
+
+      // Reset to index 2 to go back
+      await controller.reset(2);
+
+      collectedStates.clear();
+
+      // Restart from index 2
+      await tester.runAsync(() async {
+        await controller.start(
+          context,
+          firstIndex: 2,
+          force: true,
+          delay: Duration.zero,
+          onState: (state) async {
+            collectedStates.add(state);
+            if (state is TourIntroducing) {
+              await tester.pump();
+              controller.complete(IntroduceResult.next);
+            }
+          },
+        );
+      });
+
+      await tester.pumpAndSettle();
+
+      // Should show index 2 and 3
+      expect(
+        collectedStates,
+        containsAllInOrder([
+          isA<TourIntroducing>().having((s) => s.index, 'index', 2),
+          isA<TourIntroducing>().having((s) => s.index, 'index', 3),
+          isA<TourCompleted>(),
+        ]),
+      );
+    });
+
+    testWidgets('reset() does nothing when no tours have been shown', (
+      tester,
+    ) async {
+      final controller = FeaturesTourController('App');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: App(
+            tours: [
+              FeaturesTour(
+                index: 1,
+                controller: controller,
+                introduce: const Text('a.intro'),
+                child: const Text('a'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Call reset before starting any tour - should not crash
+      await controller.reset(1);
+
+      // Verify app is still functional
+      expect(find.text('a'), findsOneWidget);
+    });
+
+    testWidgets('reset() with non-existent index still works', (tester) async {
+      final controller = FeaturesTourController('App');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: App(
+            tours: [
+              FeaturesTour(
+                index: 1,
+                controller: controller,
+                introduce: const Text('a.intro'),
+                child: const Text('a'),
+              ),
+              FeaturesTour(
+                index: 2,
+                controller: controller,
+                introduce: const Text('b.intro'),
+                child: const Text('b'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      final context = tester.element(find.byType(App));
+
+      // Complete the tour
+      await tester.runAsync(() async {
+        await controller.start(
+          context,
+          force: true,
+          delay: Duration.zero,
+          onState: (state) async {
+            if (state is TourIntroducing) {
+              await tester.pump();
+              controller.complete(IntroduceResult.next);
+            }
+          },
+        );
+      });
+
+      await tester.pumpAndSettle();
+
+      // Reset with index that doesn't exist (e.g., 5.0)
+      await controller.reset(5);
+
+      final prefs = await SharedPreferences.getInstance();
+      // All existing flags should still be there (no index >= 5.0 exists)
+      expect(prefs.getBool('FeaturesTour_App_1.0'), isTrue);
+      expect(prefs.getBool('FeaturesTour_App_2.0'), isTrue);
+    });
   });
 }

--- a/test/extra_test.dart
+++ b/test/extra_test.dart
@@ -672,10 +672,10 @@ void main() {
               if (index == 1) {
                 expect(find.text('a.intro'), findsOneWidget);
                 // Programmatically complete with next
-                controller.complete(IntroduceResult.next);
+                controller.next();
               } else if (index == 2) {
                 expect(find.text('b.intro'), findsOneWidget);
-                controller.complete(IntroduceResult.done);
+                controller.done();
               }
             }
           },
@@ -746,7 +746,7 @@ void main() {
               if (index == 1) {
                 expect(find.text('a.intro'), findsOneWidget);
                 // Programmatically skip the entire tour
-                controller.complete(IntroduceResult.skip);
+                controller.skip();
               } else if (index == 2) {
                 fail('Should not reach index 2 after skip');
               }
@@ -806,7 +806,7 @@ void main() {
               await tester.pump();
               expect(find.text('a.intro'), findsOneWidget);
               // Complete with done result
-              controller.complete(IntroduceResult.done);
+              controller.done();
             }
           },
         );
@@ -852,7 +852,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Call complete before starting the tour - should not crash
-      controller.complete(IntroduceResult.next);
+      controller.next();
 
       // Verify app is still functional
       expect(find.text('a'), findsOneWidget);
@@ -899,10 +899,10 @@ void main() {
               if (index == 1) {
                 expect(find.text('a.intro'), findsOneWidget);
                 // Call complete multiple times - only first should take effect
-                controller.complete(IntroduceResult.next);
+                controller.next();
               } else if (index == 2) {
                 expect(find.text('b.intro'), findsOneWidget);
-                controller.complete(IntroduceResult.done);
+                controller.done();
               }
             }
           },
@@ -990,7 +990,7 @@ void main() {
         expect(firstIntroShown, isTrue);
 
         // Simulate external event (e.g., timer) completing the tour
-        controller.complete(IntroduceResult.next);
+        controller.next();
 
         // Wait for transition to second introduction
         await tester.pump();
@@ -998,7 +998,7 @@ void main() {
         expect(secondIntroShown, isTrue);
 
         // Complete the tour
-        controller.complete(IntroduceResult.done);
+        controller.done();
 
         // Wait for tour to finish
         await tourFuture;
@@ -1014,63 +1014,6 @@ void main() {
         containsAllInOrder([
           isA<TourIntroducing>().having((s) => s.index, 'index', 1),
           isA<TourIntroducing>().having((s) => s.index, 'index', 2),
-          isA<TourCompleted>(),
-        ]),
-      );
-    });
-
-    testWidgets('complete() works correctly with all IntroduceResult types', (
-      tester,
-    ) async {
-      // Test disabled and notMounted results
-      final controller = FeaturesTourController('App');
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: App(
-            tours: [
-              FeaturesTour(
-                index: 1,
-                controller: controller,
-                introduce: const Text('a.intro'),
-                child: const Text('a'),
-              ),
-            ],
-          ),
-        ),
-      );
-
-      await tester.pumpAndSettle();
-      final context = tester.element(find.byType(App));
-
-      await tester.runAsync(() async {
-        await controller.start(
-          context,
-          force: true,
-          delay: Duration.zero,
-          onState: (state) async {
-            collectedStates.add(state);
-            if (state is TourIntroducing) {
-              await tester.pump();
-              // Complete with disabled result (though this is typically internal)
-              controller.complete(IntroduceResult.disabled);
-            }
-          },
-        );
-      });
-
-      await tester.pumpAndSettle();
-
-      expect(
-        collectedStates,
-        containsAllInOrder([
-          isA<TourPreDialogHidden>(),
-          isA<TourIntroducing>(),
-          isA<TourIntroduceResultEmitted>().having(
-            (s) => s.result,
-            'result',
-            IntroduceResult.disabled,
-          ),
           isA<TourCompleted>(),
         ]),
       );
@@ -1120,7 +1063,7 @@ void main() {
           onState: (state) async {
             if (state is TourIntroducing) {
               await tester.pump();
-              controller.complete(IntroduceResult.next);
+              controller.next();
             }
           },
         );
@@ -1190,7 +1133,7 @@ void main() {
           onState: (state) async {
             if (state is TourIntroducing) {
               await tester.pump();
-              controller.complete(IntroduceResult.next);
+              controller.next();
             }
           },
         );
@@ -1214,7 +1157,7 @@ void main() {
             collectedStates.add(state);
             if (state is TourIntroducing) {
               await tester.pump();
-              controller.complete(IntroduceResult.next);
+              controller.next();
             }
           },
         );
@@ -1334,7 +1277,7 @@ void main() {
           onState: (state) async {
             if (state is TourIntroducing) {
               await tester.pump();
-              controller.complete(IntroduceResult.next);
+              controller.next();
             }
           },
         );
@@ -1396,7 +1339,7 @@ void main() {
           onState: (state) async {
             if (state is TourIntroducing) {
               await tester.pump();
-              controller.complete(IntroduceResult.next);
+              controller.next();
             }
           },
         );
@@ -1419,7 +1362,7 @@ void main() {
             collectedStates.add(state);
             if (state is TourIntroducing) {
               await tester.pump();
-              controller.complete(IntroduceResult.next);
+              controller.next();
             }
           },
         );
@@ -1484,10 +1427,10 @@ void main() {
             if (state case TourIntroducing(index: final index)) {
               await tester.pump();
               if (index == 1 || index == 2) {
-                controller.complete(IntroduceResult.next);
+                controller.next();
               } else if (index == 3) {
                 // User wants to go back to index 2
-                controller.complete(IntroduceResult.skip);
+                controller.skip();
               }
             }
           },
@@ -1512,7 +1455,7 @@ void main() {
             collectedStates.add(state);
             if (state is TourIntroducing) {
               await tester.pump();
-              controller.complete(IntroduceResult.next);
+              controller.next();
             }
           },
         );
@@ -1596,7 +1539,7 @@ void main() {
           onState: (state) async {
             if (state is TourIntroducing) {
               await tester.pump();
-              controller.complete(IntroduceResult.next);
+              controller.next();
             }
           },
         );

--- a/test/extra_test.dart
+++ b/test/extra_test.dart
@@ -631,9 +631,7 @@ void main() {
       );
     });
 
-    testWidgets('complete() with IntroduceResult.next moves to next step', (
-      tester,
-    ) async {
+    testWidgets('next() should move to next step', (tester) async {
       final controller = FeaturesTourController('App');
 
       await tester.pumpWidget(
@@ -705,9 +703,7 @@ void main() {
       );
     });
 
-    testWidgets('complete() with IntroduceResult.skip stops the tour', (
-      tester,
-    ) async {
+    testWidgets('skip() should stop the tour', (tester) async {
       final controller = FeaturesTourController('App');
 
       await tester.pumpWidget(
@@ -772,9 +768,7 @@ void main() {
       );
     });
 
-    testWidgets('complete() with IntroduceResult.done completes the tour', (
-      tester,
-    ) async {
+    testWidgets('done() should complete the tour', (tester) async {
       final controller = FeaturesTourController('App');
 
       await tester.pumpWidget(
@@ -829,7 +823,7 @@ void main() {
       );
     });
 
-    testWidgets('complete() does nothing when tour is not active', (
+    testWidgets('next() should do nothing when tour is not active', (
       tester,
     ) async {
       final controller = FeaturesTourController('App');
@@ -858,166 +852,92 @@ void main() {
       expect(find.text('a'), findsOneWidget);
     });
 
-    testWidgets('complete() does nothing when called multiple times', (
-      tester,
-    ) async {
-      final controller = FeaturesTourController('App');
+    testWidgets(
+      'next() and done() can be used with external events like timers',
+      (tester) async {
+        final controller = FeaturesTourController('App');
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: App(
-            tours: [
-              FeaturesTour(
-                index: 1,
-                controller: controller,
-                introduce: const Text('a.intro'),
-                child: const Text('a'),
-              ),
-              FeaturesTour(
-                index: 2,
-                controller: controller,
-                introduce: const Text('b.intro'),
-                child: const Text('b'),
-              ),
-            ],
+        await tester.pumpWidget(
+          MaterialApp(
+            home: App(
+              tours: [
+                FeaturesTour(
+                  index: 1,
+                  controller: controller,
+                  introduce: const Text('a.intro'),
+                  child: const Text('a'),
+                ),
+                FeaturesTour(
+                  index: 2,
+                  controller: controller,
+                  introduce: const Text('b.intro'),
+                  child: const Text('b'),
+                ),
+              ],
+            ),
           ),
-        ),
-      );
-
-      await tester.pumpAndSettle();
-      final context = tester.element(find.byType(App));
-
-      await tester.runAsync(() async {
-        await controller.start(
-          context,
-          force: true,
-          delay: Duration.zero,
-          onState: (state) async {
-            collectedStates.add(state);
-            if (state case TourIntroducing(index: final index)) {
-              await tester.pump();
-              if (index == 1) {
-                expect(find.text('a.intro'), findsOneWidget);
-                // Call complete multiple times - only first should take effect
-                controller.next();
-              } else if (index == 2) {
-                expect(find.text('b.intro'), findsOneWidget);
-                controller.done();
-              }
-            }
-          },
-        );
-      });
-
-      await tester.pumpAndSettle();
-
-      // Should have moved to next (first complete call), not skip or done
-      expect(
-        collectedStates,
-        containsAllInOrder([
-          isA<TourPreDialogHidden>(),
-          isA<TourIntroducing>().having((s) => s.index, 'index', 1),
-          isA<TourIntroduceResultEmitted>().having(
-            (s) => s.result,
-            'result',
-            IntroduceResult.next,
-          ),
-          isA<TourIntroducing>().having((s) => s.index, 'index', 2),
-          isA<TourIntroduceResultEmitted>().having(
-            (s) => s.result,
-            'result',
-            IntroduceResult.done,
-          ),
-          isA<TourCompleted>(),
-        ]),
-      );
-    });
-
-    testWidgets('complete() can be used with external events like timers', (
-      tester,
-    ) async {
-      final controller = FeaturesTourController('App');
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: App(
-            tours: [
-              FeaturesTour(
-                index: 1,
-                controller: controller,
-                introduce: const Text('a.intro'),
-                child: const Text('a'),
-              ),
-              FeaturesTour(
-                index: 2,
-                controller: controller,
-                introduce: const Text('b.intro'),
-                child: const Text('b'),
-              ),
-            ],
-          ),
-        ),
-      );
-
-      await tester.pumpAndSettle();
-      final context = tester.element(find.byType(App));
-
-      var firstIntroShown = false;
-      var secondIntroShown = false;
-
-      await tester.runAsync(() async {
-        // Start tour with state tracking
-        final tourFuture = controller.start(
-          context,
-          force: true,
-          delay: Duration.zero,
-          onState: (state) async {
-            collectedStates.add(state);
-            if (state case TourIntroducing(index: final index)) {
-              await tester.pump();
-              if (index == 1) {
-                firstIntroShown = true;
-              } else if (index == 2) {
-                secondIntroShown = true;
-              }
-            }
-          },
         );
 
-        // Wait for first introduction to appear
-        await tester.pump();
-        await Future<void>.delayed(const Duration(milliseconds: 100));
-        expect(firstIntroShown, isTrue);
+        await tester.pumpAndSettle();
+        final context = tester.element(find.byType(App));
 
-        // Simulate external event (e.g., timer) completing the tour
-        controller.next();
+        var firstIntroShown = false;
+        var secondIntroShown = false;
 
-        // Wait for transition to second introduction
-        await tester.pump();
-        await Future<void>.delayed(const Duration(milliseconds: 100));
-        expect(secondIntroShown, isTrue);
+        await tester.runAsync(() async {
+          // Start tour with state tracking
+          final tourFuture = controller.start(
+            context,
+            force: true,
+            delay: Duration.zero,
+            onState: (state) async {
+              collectedStates.add(state);
+              if (state case TourIntroducing(index: final index)) {
+                await tester.pump();
+                if (index == 1) {
+                  firstIntroShown = true;
+                } else if (index == 2) {
+                  secondIntroShown = true;
+                }
+              }
+            },
+          );
 
-        // Complete the tour
-        controller.done();
+          // Wait for first introduction to appear
+          await tester.pump();
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          expect(firstIntroShown, isTrue);
 
-        // Wait for tour to finish
-        await tourFuture;
-      });
+          // Simulate external event (e.g., timer) completing the tour
+          controller.next();
 
-      await tester.pumpAndSettle();
+          // Wait for transition to second introduction
+          await tester.pump();
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          expect(secondIntroShown, isTrue);
 
-      // Verify tour completed successfully
-      expect(find.text('a.intro'), findsNothing);
-      expect(find.text('b.intro'), findsNothing);
-      expect(
-        collectedStates,
-        containsAllInOrder([
-          isA<TourIntroducing>().having((s) => s.index, 'index', 1),
-          isA<TourIntroducing>().having((s) => s.index, 'index', 2),
-          isA<TourCompleted>(),
-        ]),
-      );
-    });
+          // Complete the tour
+          controller.done();
+
+          // Wait for tour to finish
+          await tourFuture;
+        });
+
+        await tester.pumpAndSettle();
+
+        // Verify tour completed successfully
+        expect(find.text('a.intro'), findsNothing);
+        expect(find.text('b.intro'), findsNothing);
+        expect(
+          collectedStates,
+          containsAllInOrder([
+            isA<TourIntroducing>().having((s) => s.index, 'index', 1),
+            isA<TourIntroducing>().having((s) => s.index, 'index', 2),
+            isA<TourCompleted>(),
+          ]),
+        );
+      },
+    );
 
     testWidgets('reset() clears shown flags from target index onwards', (
       tester,


### PR DESCRIPTION
I made a few changes and please let me know your thoughts.

1. Moved the complete function out of _showIntroduce as suggested, so that the state of the tour could be controlled through the controller. 
2. Added a new reset and _clearShownFlagsFrom so that we can restart the tour at any given index. The use case for this change is to be able to back to the previous item and then complete the tour from there. 
3. Removed the IgnorePointer and adjusted the Scaffold within lib/src/components/features_child.dart. Cause it is not allowing tap events from the customized introduce widget. 